### PR TITLE
fixed Negated character classes #26

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -453,7 +453,7 @@ class Builder extends TestMethodProvider
      * @return Builder
      */
     public function exactly(int $count, $rest = Null ) : self
-    {	
+    {
         $this->validateAndAddMethodType(self::METHOD_TYPE_QUANTIFIER, self::METHOD_TYPE_CHARACTER | self::METHOD_TYPE_GROUP);
 		if( $rest != Null )
 		{

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -416,10 +416,13 @@ class Builder extends TestMethodProvider
      * @param int $min
      * @return Builder
      */
-    public function atLeast(int $min) : self
+    public function atLeast(int $min, $rest = Null ) : self
     {
         $this->validateAndAddMethodType(self::METHOD_TYPE_QUANTIFIER, self::METHOD_TYPE_CHARACTER | self::METHOD_TYPE_GROUP);
-
+		if( $rest != Null )
+		{
+			throw new SyntaxException();
+		}
         return $this->add(sprintf('{%d,}', $min));
     }
 
@@ -449,10 +452,13 @@ class Builder extends TestMethodProvider
      * @param int $count
      * @return Builder
      */
-    public function exactly(int $count) : self
-    {
+    public function exactly(int $count, $rest = Null ) : self
+    {	
         $this->validateAndAddMethodType(self::METHOD_TYPE_QUANTIFIER, self::METHOD_TYPE_CHARACTER | self::METHOD_TYPE_GROUP);
-
+		if( $rest != Null )
+		{
+			throw new SyntaxException();
+		}
         return $this->add(sprintf('{%d}', $count));
     }
 

--- a/tests/ExceptionsTest.php
+++ b/tests/ExceptionsTest.php
@@ -121,4 +121,22 @@ class ExceptionsTest extends TestCase
     {
         new SRL('literally (literally "foo")');
     }
+	
+	/**
+     * @expectedException  \SRL\Exceptions\SyntaxException
+     * @expectedExceptionMessage Invalid parameter given for `exactly`.
+     */
+    public function testInvalidExactlyArgument()
+    {
+        new SRL('letter exactly 2 times,not digit');
+    }
+
+	/**
+     * @expectedException  \SRL\Exceptions\SyntaxException
+     * @expectedExceptionMessage Invalid parameter given for `at least`.
+     */
+    public function testInvalidAtLeastArgument()
+    {
+        new SRL('letter at least 2 times,but digit');
+    }
 }


### PR DESCRIPTION
Function `exactly` should only accept one parameter. Everything that is
not matched as a method after the `times` keyword is passed to the
`exactly` as additional parameter - but as `exactly` takes exactly one
parameter, the additional are ignored.