### PR TITLE
fix - Negated character classes #26 (#1)

### DIFF
--- a/src/Language/Helpers/Matcher.php
+++ b/src/Language/Helpers/Matcher.php
@@ -55,8 +55,8 @@ class Matcher
         'number from' => ['class' => Methods\ToMethod::class, 'method' => 'digit'],
         'letter from' => ['class' => Methods\ToMethod::class, 'method' => 'letter'],
         'uppercase letter from' => ['class' => Methods\ToMethod::class, 'method' => 'uppercaseLetter'],
-        'exactly' => ['class' => Methods\AndMethod::class, 'method' => 'exactly'],
-        'at least' => ['class' => Methods\AndMethod::class, 'method' => 'atLeast'],
+        'exactly' => ['class' => Methods\TimesMethod::class, 'method' => 'exactly'],
+        'at least' => ['class' => Methods\TimesMethod::class, 'method' => 'atLeast'],
         'between' => ['class' => Methods\AndMethod::class, 'method' => 'between'],
         'capture' => ['class' => Methods\AsMethod::class, 'method' => 'capture'],
     ];

--- a/src/Language/Methods/TimesMethod.php
+++ b/src/Language/Methods/TimesMethod.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SRL\Language\Methods;
+
+use SRL\Exceptions\SyntaxException;
+use SRL\Interfaces\Method;
+
+/**
+ * Method having one or two parameters. First is simple, ignoring second "time" or "times". Will throw SyntaxException if more parameters provided.
+ */
+class TimesMethod extends Method
+{
+    public function setParameters(array $params) : Method
+    {
+        $params = array_filter($params, function ($item) {
+            if (!is_string($item)) {
+                return true;
+            }
+
+            $lower = strtolower($item);
+            return $lower != 'times' && $lower != 'time';
+        });
+
+		if( count( $params ) > 1 )
+		{
+			throw new SyntaxException('Invalid parameter.');			
+		}
+
+        return parent::setParameters($params);
+    }
+}

--- a/src/Language/Methods/TimesMethod.php
+++ b/src/Language/Methods/TimesMethod.php
@@ -21,10 +21,9 @@ class TimesMethod extends Method
             return $lower != 'times' && $lower != 'time';
         });
 
-		if( count( $params ) > 1 )
-		{
-			throw new SyntaxException('Invalid parameter.');			
-		}
+        if (count($params) > 1) {
+            throw new SyntaxException('Invalid parameter.');
+        }
 
         return parent::setParameters($params);
     }

--- a/tests/ExceptionsTest.php
+++ b/tests/ExceptionsTest.php
@@ -121,8 +121,8 @@ class ExceptionsTest extends TestCase
     {
         new SRL('literally (literally "foo")');
     }
-	
-	/**
+
+    /**
      * @expectedException  \SRL\Exceptions\SyntaxException
      * @expectedExceptionMessage Invalid parameter given for `exactly`.
      */
@@ -131,7 +131,7 @@ class ExceptionsTest extends TestCase
         new SRL('letter exactly 2 times,not digit');
     }
 
-	/**
+    /**
      * @expectedException  \SRL\Exceptions\SyntaxException
      * @expectedExceptionMessage Invalid parameter given for `at least`.
      */

--- a/tests/ExceptionsTest.php
+++ b/tests/ExceptionsTest.php
@@ -121,4 +121,22 @@ class ExceptionsTest extends TestCase
     {
         new SRL('literally (literally "foo")');
     }
+	
+	/**
+     * @expectedException  \SRL\Exceptions\SyntaxException
+     * @expectedExceptionMessage Invalid parameter given for `exactly`.
+     */
+    public function testInvalidExactlyArgument()
+    {
+        new SRL('letter exactly 2 times,not digit');
+    }
+
+	/**
+     * @expectedException  \SRL\Exceptions\SyntaxException
+     * @expectedExceptionMessage Invalid parameter given for `at least`.
+     */
+    public function testInvalidAtLeastArgument()
+    {
+        new SRL('letter at least 2 times,but digit');
+    }
 }

--- a/tests/LanguageInterpreterTest.php
+++ b/tests/LanguageInterpreterTest.php
@@ -36,6 +36,14 @@ class LanguageInterpreterTest extends TestCase
         $this->assertFalse($srl->isMatching('444444'));
         $this->assertFalse($srl->isMatching('1'));
         $this->assertFalse($srl->isMatching('563'));
+       
+        $srl = new SRL('starts with digit exactly 2 times, letter at least 3 time');
+        $this->assertEquals('/^[0-9]{2}[a-z]{3,}/', $srl->get());
+        $this->assertTrue($srl->isMatching('12abc'));
+        $this->assertTrue($srl->isMatching('12abcd'));
+        $this->assertFalse($srl->isMatching('123abc'));
+        $this->assertFalse($srl->isMatching('1a'));
+        $this->assertFalse($srl->isMatching(''));
     }
 
     public function testEmail()

--- a/tests/LanguageInterpreterTest.php
+++ b/tests/LanguageInterpreterTest.php
@@ -36,7 +36,7 @@ class LanguageInterpreterTest extends TestCase
         $this->assertFalse($srl->isMatching('444444'));
         $this->assertFalse($srl->isMatching('1'));
         $this->assertFalse($srl->isMatching('563'));
-       
+
         $srl = new SRL('starts with digit exactly 2 times, letter at least 3 time');
         $this->assertEquals('/^[0-9]{2}[a-z]{3,}/', $srl->get());
         $this->assertTrue($srl->isMatching('12abc'));


### PR DESCRIPTION
* fix - Negated character classes #26
-Add new TimesMethod that allow only one parameter passed, ignoring
optional time[s]. Will raise Syntax exception if more parameters passed.
-Use TimesMethod for 'exactly' and 'atLeast' functions.